### PR TITLE
config(beads): disable auto-flush and auto-import for manual control

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -20,9 +20,11 @@ no-daemon: true
 
 # Disable auto-flush of database to JSONL after mutations
 # no-auto-flush: false
+no-auto-flush: true
 
 # Disable auto-import from JSONL when it's newer than database
 # no-auto-import: false
+no-auto-import: true
 
 # Enable JSON output by default
 # json: false


### PR DESCRIPTION
# config(beads): disable auto-flush and auto-import for manual control

## Overview

beads設定で自動処理オプションを無効化し、手動制御を可能にします。
セッション管理の予測可能性向上のため、自動フラッシュと自動インポートを停止します。

---

## Changes

List the key changes included in this PR:

- [x] Added/updated files or modules
  - `.beads/config.yaml`: `no-auto-flush: true` と `no-auto-import: true` を追加
- [ ] Removed deprecated logic or configs
- [ ] Refactored [X] for clarity/performance
- [ ] Other (please describe below)

---

## Related Issues

> N/A - 設定改善タスク

---

## Checklist

Please confirm the following before requesting review:

- [x] Lint checks pass (`pnpm lint`)
- [x] Tests pass (`pnpm test`)
- [x] Documentation is updated (if applicable)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Descriptions and examples are clear

---

## Additional Notes

**変更理由:**
- `no-auto-flush: true`: データベース変更後の自動JSONLフラッシュを無効化
- `no-auto-import: true`: JSONL更新時の自動インポートを無効化

これにより `bd sync` コマンドで明示的に同期を制御できるようになります。

---

Generated with [Claude Code](https://claude.ai/code)
