### PR TITLE
fix(deps): add js-yaml to devDependencies and relax version constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint": "^10.5.0",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
+    "js-yaml": "~4.2.0",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "eslint": "^10.5.0",
     "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
-    "js-yaml": "~4.2.0",
+    "js-yaml": ">=4.2.0",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "tsx": "^4.22.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.5.0)
+      js-yaml:
+        specifier: ~4.2.0
+        version: 4.2.0
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ importers:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.61.1(eslint@10.5.0)(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@10.5.0)
       js-yaml:
-        specifier: ~4.2.0
+        specifier: '>=4.2.0'
         version: 4.2.0
       rimraf:
         specifier: ^6.1.3


### PR DESCRIPTION
## Overview

**Summary**
Add js-yaml as an explicit devDependency to pin a patched version and fix a known vulnerability.

**Background / Motivation**
js-yaml was not listed in devDependencies, so pnpm could not enforce a secure version via the lockfile. This PR adds an explicit `>=4.2.0` constraint so the patched version is always resolved.

## Changes

### Core Changes

- `package.json`: Add `"js-yaml": ">=4.2.0"` to `devDependencies`
- `pnpm-lock.yaml`: Sync specifier from `~4.2.0` to `>=4.2.0` to match the new constraint

### Test Updates

N/A

### Removed

N/A

## Change Type (optional)

Select all that apply:

- [ ] Feature
- [x] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Configuration
- [ ] CI/CD
- [ ] Other

## Related Issues

> N/A

## Checklist

Please confirm the following (if applicable):

- [ ] Formatting and lint checks pass (e.g. `dprint check`, `pnpm lint`)
- [ ] Tests pass (if test suite exists)
- [ ] Documentation updated (for user-facing changes)
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Shared types and utilities are imported from common modules, not inlined in implementation files

## Additional Notes

Security patch only — no application code changed. The `>=4.2.0` floor ensures the vulnerable version is never resolved while staying flexible for future patch releases.
